### PR TITLE
Update objects.py

### DIFF
--- a/vkbottle_types/codegen/objects.py
+++ b/vkbottle_types/codegen/objects.py
@@ -6916,6 +6916,7 @@ class CallbackLikeAddRemoveObjectType(enum.Enum):
     VIDEO_COMMENT = "video_comment"
     MARKET = "market"
     MARKET_COMMENT = "market_comment"
+    CLIP = "clip"
 
 
 class CallbackLikeAddRemove(BaseModel):


### PR DESCRIPTION
По какой то странной причине лайк клипа вызывает ошибку

pydantic.v1.error_wrappers.ValidationError: 1 validation error for LikeAdd
object -> object_type
  value is not a valid enumeration member; permitted: 'video', 'photo', 'post', 'comment', 'note', 'topic_comment', 'photo_comment', 'video_comment', 'market', 'market_comment' (type=type_error.enum; enum_values=[<CallbackLikeAddRemoveObjectType.VIDEO: 'video'>....
  
  event = {'group_id': , 'type': 'like_add', 'event_id': '', 'v': '5.199', 'object': {'liker_id': , 'object_type': 'clip', 'object_owner_id': -2, 'object_id': 4, 'thread_reply_id': 0, 'post_id': 0}}